### PR TITLE
n_way_buffering fix for Windows

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -21,6 +21,8 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
+#
+
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -28,9 +28,16 @@ endif()
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
-set(EMULATOR_LINK_FLAGS " -lpthread -fintelfpga")
+if(WIN32)
+	set(EMULATOR_LINK_FLAGS " -fintelfpga")
+	set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+else()
+	set(EMULATOR_LINK_FLAGS " -lpthread -fintelfpga")
+	set(HARDWARE_LINK_FLAGS "-lpthread -fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+endif()
+
 set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
-set(HARDWARE_LINK_FLAGS "-lpthread -fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -21,8 +21,6 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-##
-
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-#
+##
 
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).


### PR DESCRIPTION
# Existing Sample Changes
## Description

Changed the CMakeLists.txt for the n_way_buffering tutorial. -lpthread was erroneously added back as a compiler argument for Windows and reports. I've removed it.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Ran the regtest in Windows it now passes.
Tested Linux too.

